### PR TITLE
Btns + link hover colors

### DIFF
--- a/static/css/add-on.css
+++ b/static/css/add-on.css
@@ -235,3 +235,14 @@
     table-layout: fixed;
     width: 100%
 	}
+	
+/* Share buttons */
+	
+	
+	.share-btn.twitter     { background: #e65c00; }
+	.share-btn.facebook    { background: #ffa31a; }
+	.share-btn.email       { background: #ffcc00; }
+
+	  .share-btn.twitter:hover     { background: #ed8c4c; }
+	  .share-btn.facebook:hover    { background: #ffbe5e; }
+	  .share-btn.email:hover       { background: #ffe066; }

--- a/static/css/add-on.css
+++ b/static/css/add-on.css
@@ -246,3 +246,14 @@
 	  .share-btn.twitter:hover     { background: #ed8c4c; }
 	  .share-btn.facebook:hover    { background: #ffbe5e; }
 	  .share-btn.email:hover       { background: #ffe066; }
+
+/* Link hover colors */
+
+		a:hover {
+			border-bottom-color: transparent;
+			color: #BC45C4 !important;
+		}
+
+			a:hover:before {
+				color: #BC45C4 !important;
+			}


### PR DESCRIPTION
This PR can be merged in independent of the other one that fixes the image paths. Here we update the link hover color and the social sharing button colors. I used the hex color codes you gave me for both, and for the buttons I made the hover colors just slightly lighter tones of the same colors. Now that you have the CSS though, you can play to your heart's content! 